### PR TITLE
Add 0.5.2 release to appdata

### DIFF
--- a/io.kinvolk.Headlamp.appdata.xml
+++ b/io.kinvolk.Headlamp.appdata.xml
@@ -28,6 +28,7 @@
   <launchable type="desktop-id">io.kinvolk.Headlamp.desktop</launchable>
 
   <releases>
+    <release version="0.5.2" date="2021-09-21" />
     <release version="0.5.1" date="2021-08-25" />
     <release version="0.5.0" date="2021-08-25" />
     <release version="0.4.0" date="2021-06-23" />


### PR DESCRIPTION
This was forgotten in the previous version bump.