### PR TITLE
Use freedesktop SDK 23.08 runtime

### DIFF
--- a/io.kinvolk.Headlamp.yaml
+++ b/io.kinvolk.Headlamp.yaml
@@ -1,9 +1,9 @@
 app-id: io.kinvolk.Headlamp
 runtime: org.freedesktop.Platform
-runtime-version: '22.08'
+runtime-version: '23.08'
 sdk: org.freedesktop.Sdk
 base: org.electronjs.Electron2.BaseApp
-base-version: '22.08'
+base-version: '23.08'
 command: run-headlamp.sh
 separate-locales: false
 rename-desktop-file: headlamp.desktop


### PR DESCRIPTION
The newer freedesktop SDK brings updated libraries and packages.
See https://gitlab.com/freedesktop-sdk/freedesktop-sdk/-/releases/freedesktop-sdk-23.08.0