### PR TITLE
Fix using external tools from kubeconfig

### DIFF
--- a/io.kinvolk.Headlamp.yaml
+++ b/io.kinvolk.Headlamp.yaml
@@ -15,11 +15,11 @@ finish-args:
 - --device=dri
 - --share=network
 # We use .kube/config to know what clusters/contexts are set up
-- --filesystem=~/.kube/config:ro
+- --filesystem=~/.kube/config
 # It's common to run minikube for experimenting, so it should be fine to read this dir
-- --filesystem=~/.minikube:ro
+- --filesystem=~/.minikube
 # Config folder
-- --filesystem=~/.config/Headlamp:ro
+- --filesystem=~/.config/Headlamp
 modules:
 - name: headlamp
   buildsystem: simple

--- a/io.kinvolk.Headlamp.yaml
+++ b/io.kinvolk.Headlamp.yaml
@@ -20,6 +20,11 @@ finish-args:
 - --filesystem=~/.minikube
 # Config folder
 - --filesystem=~/.config/Headlamp
+# Public cloud configs that we may need access
+- --filesystem=~/.aws
+- --filesystem=~/.azure
+- --filesystem=~/.config/doctl
+- --filesystem=~/.config/gcloud
 modules:
 - name: headlamp
   buildsystem: simple

--- a/io.kinvolk.Headlamp.yaml
+++ b/io.kinvolk.Headlamp.yaml
@@ -48,6 +48,18 @@ modules:
   - rm ./headlamp/chrome-sandbox
   - install -d /app/headlamp-app/
   - cp -R ./headlamp/* /app/headlamp-app/
+- name: k8s-tools
+  buildsystem: simple
+  build-options:
+    env:
+      TOOLS_TO_WRAP: aliyunl;aws;az;doctl;gcloud;helm;ibmcloud;k3s;kind;kubectl;kubelogin;minikube;oc
+  sources:
+  - type: file
+    path: ./setup-tool-wrapper.sh
+  build-commands:
+  - chmod a+x ./setup-tool-wrapper.sh
+  - mkdir tools && cd tools && ../setup-tool-wrapper.sh $TOOLS_TO_WRAP
+  - for tool in $(ls tools); do install -Dm 755 tools/$tool /app/bin/$tool; done
 - name: start-script
   buildsystem: simple
   sources:

--- a/setup-tool-wrapper.sh
+++ b/setup-tool-wrapper.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# Check if the tool name is provided
+if [ -z "$1" ]; then
+  echo "Usage: $0 <tool-name-or-tools-separated-by-semicolon>"
+  exit 1
+fi
+
+function setup-tool() {
+  # Get the tool name from the first argument
+  TOOL_NAME=$1
+
+  # Create the script content
+  SCRIPT_CONTENT="flatpak-spawn --host bash --login -c $TOOL_NAME \"\$@\""
+
+  # Create the new script file with the tool name
+  echo "$SCRIPT_CONTENT" > "$TOOL_NAME"
+
+  # Make the new script file executable
+  chmod +x "$TOOL_NAME"
+
+  echo "Wrapper script for $TOOL_NAME created successfully."
+}
+
+TOOLS=$1
+
+# Check if the tools in $TOOLS is one or more tools
+if [[ $TOOLS == *";"* ]]; then
+  # Split the tools by semicolon
+  IFS=';' read -ra TOOLS <<< "$TOOLS"
+fi
+
+# Iterate over each tool and create the wrapper script
+for TOOL in "${TOOLS[@]}"; do
+  # Create the script content
+  setup-tool "$TOOL"
+done


### PR DESCRIPTION
Recently, users have complained that they cannot run tools like `aws` or `kubelogin` from this version of Headlamp.
This PR should fix that. I am not very happy with the change that gives access to the home and host by default, but without it I am afraid that users will just say that the tools are not able to access any config files or libs they need.