### PR TITLE
Bump runtimes to 25.08

### DIFF
--- a/io.kinvolk.Headlamp.yaml
+++ b/io.kinvolk.Headlamp.yaml
@@ -1,9 +1,9 @@
 app-id: io.kinvolk.Headlamp
 runtime: org.freedesktop.Platform
-runtime-version: '24.08'
+runtime-version: '25.08'
 sdk: org.freedesktop.Sdk
 base: org.electronjs.Electron2.BaseApp
-base-version: '24.08'
+base-version: '25.08'
 command: run-headlamp.sh
 separate-locales: false
 rename-desktop-file: headlamp.desktop


### PR DESCRIPTION
https://discourse.flathub.org/t/freedesktop-sdk-25-08-0-released/10399
https://gitlab.com/freedesktop-sdk/freedesktop-sdk/-/blob/release/25.08/NEWS.yml