### PR TITLE
feat: add oci CLI wrapper for Oracle Cloud connectivity

### DIFF
--- a/io.kinvolk.Headlamp.yaml
+++ b/io.kinvolk.Headlamp.yaml
@@ -60,7 +60,7 @@ modules:
   buildsystem: simple
   build-options:
     env:
-      TOOLS_TO_WRAP: aliyunl;aws;az;doctl;gcloud;helm;ibmcloud;k3s;kind;kubectl;kubelogin;minikube;oc
+      TOOLS_TO_WRAP: aliyunl;aws;az;doctl;gcloud;helm;ibmcloud;k3s;kind;kubectl;kubelogin;minikube;oc;oci
   sources:
   - type: file
     path: ./setup-tool-wrapper.sh


### PR DESCRIPTION
Adds the Oracle Cloud Infrastructure CLI (`oci`) to the set of host-delegated tool wrappers. This allows Headlamp to invoke `oci` (via `flatpak-spawn --host`) for OKE cluster authentication when the user has the OCI CLI installed on their host.

The `~/.oci` filesystem access was already added in a prior commit.