### PR TITLE
fix: add --talk-name=org.freedesktop.Flatpak so host tool wrappers work

### DIFF
--- a/io.kinvolk.Headlamp.yaml
+++ b/io.kinvolk.Headlamp.yaml
@@ -14,6 +14,9 @@ finish-args:
 - --socket=wayland
 - --device=dri
 - --share=network
+# Needed so the k8s-tools wrappers can run host CLIs via flatpak-spawn --host
+# See: https://github.com/kubernetes-sigs/headlamp/issues/1341
+- --talk-name=org.freedesktop.Flatpak
 # We use .kube/config to know what clusters/contexts are set up
 - --filesystem=~/.kube/config
 # It's common to run minikube for experimenting, so it should be fine to read this dir


### PR DESCRIPTION
The [k8s-tools](https://github.com/yolossn/io.kinvolk.Headlamp/blob/742866e5a1ad42dcbc65974fe203fc397e0f5749/io.kinvolk.Headlamp.yaml#L63) module installs host-forwarding wrapper scripts for kubectl, kubelogin, az, gcloud, doctl and other tools. Each wrapper shells out to the user's host-installed binary via `flatpak-spawn --host`, which requires the sandbox to be allowed to talk to the org.freedesktop.Flatpak portal.

That permission was missing from finish-args, so every wrapper failed with org.freedesktop.DBus.Error.ServiceUnknown error. Verified that kubectl/kubelogin/az wrappers all fail identically on the shipped manifest and work once this permission is granted.

<img width="2338" height="822" alt="image" src="https://github.com/user-attachments/assets/6cdfc1e3-f87b-405d-b76a-ecb9d5acc171" />
<img width="2338" height="390" alt="image" src="https://github.com/user-attachments/assets/fe54cb7e-c191-4c9a-a7b4-83179e630a7d" />
<img width="2338" height="1086" alt="image" src="https://github.com/user-attachments/assets/cfcf91ed-4bc6-4f21-bd6e-08c94e81cf09" />

Fixes https://github.com/kubernetes-sigs/headlamp/issues/1341